### PR TITLE
accept php 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     }
   ],
   "require": {
-    "php": "^8.4",
+    "php": "^8.4|^8.2",
     "illuminate/contracts": "^11.0||^12.0",
     "livewire/livewire": "^3.0||^4.0",
     "spatie/laravel-package-tools": "^1.16"


### PR DESCRIPTION
I couldnt use this package in projects running php8.2. I believe this shouldnt be blocked due to backward compatibilty.

<img width="935" height="221" alt="Image" src="https://github.com/user-attachments/assets/dac11bdf-e464-4894-8577-b22d6d2d2399" />